### PR TITLE
不適当な索引項目が Symbols 項に入ってしまう問題の修正

### DIFF
--- a/ptex-manual.tex
+++ b/ptex-manual.tex
@@ -501,12 +501,12 @@ p3.1.2で復活したという経緯がある．}．
 
 \pTeX では\TeX82に加えて以下の単位が使用可能である：
 \begin{cslist}
- \csitem[\texttt{zw}\index{\texttt{zw}}]
+ \csitem[\texttt{zw}\index{zw=\texttt{zw}}]
   現在の和文フォント（通常の縦組のときは縦組用フォント，それ以外のときは横組用フォント）
   における「全角幅」．例えばこの文書の本文では
   $1\,\mathrm{zw} = \makeatletter\strip@pt\dimexpr 1zw\,\mathrm{pt}$である．
 
- \csitem[\texttt{zh}\index{\texttt{zh}}]
+ \csitem[\texttt{zh}\index{zh=\texttt{zh}}]
   現在の和文フォント（通常の縦組のときは縦組用フォント，それ以外のときは横組用フォント）
   における「全角高さ」．例えばこの文書の本文では
   $1\,\mathrm{zh} = \makeatletter\strip@pt\dimexpr 1zh\,\mathrm{pt}$である．
@@ -532,7 +532,7 @@ p3.1.2で復活したという経緯がある．}．
 \end{dangerous}
 
 \begin{cslist}
- \csitem[\texttt{Q}\index{\texttt{Q}}, \texttt{H}\index{\texttt{H}}]
+ \csitem[\texttt{Q}\index{Q=\texttt{Q}}, \texttt{H}\index{H=\texttt{H}}]
   両者とも$0.25\,\mathrm{mm}$~($7227/10160\,\mathrm{sp}$)を意味する．
   写植機における文字の大きさの単位であるQ数（級数）と，字送り量や行送り量の単位である歯数に由来する．
 \end{cslist}


### PR DESCRIPTION
`\index{\texttt{foo}}` をやると “foo” エントリ自体は F 項に入るべきところが Symbols 項に入ってしまうので，sorting 用の文字列を足しました．

なお，gist.ind の設定では makeindex の actual パラメタは `@` ではなく `=` なので，それに対応しています．